### PR TITLE
Added Coua support

### DIFF
--- a/examples/coua/mqtt-client/Makefile
+++ b/examples/coua/mqtt-client/Makefile
@@ -1,0 +1,10 @@
+DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
+
+all: mqtt-client.bin
+
+CONTIKI_WITH_IPV6 = 1
+
+APPS += mqtt
+
+CONTIKI=../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/coua/mqtt-client/mqtt-client.c
+++ b/examples/coua/mqtt-client/mqtt-client.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *      mqtt-client.c
+ */
+
+#include "project-conf.h"
+#include "contiki.h"
+
+#include "mqtt-client.h"
+#include "mqtt.h"
+
+#include "rpl.h"
+
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+AUTOSTART_PROCESSES(&mqtt_client_process);
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+static struct mqtt_connection conn;
+static mqtt_configuration conf = { MQTT_BROKER_IP,
+                  MQTT_BROKER_PORT,
+                  MQTT_PUBLISH_INTERVAL,
+                  MQTT_CLIENT_DEFAULT_ORG_ID,
+                  MQTT_CLIENT_DEFAULT_TYPE_ID };
+
+static mqtt_client_message msg;
+static char client_id[MQTT_CLIENT_ID_LEN];
+/*---------------------------------------------------------------------------*/
+
+void
+mqtt_event_handler(struct mqtt_connection *m, mqtt_event_t event, void *data){
+  switch (event) {
+    case MQTT_EVENT_CONNECTED:
+      process_poll(&mqtt_client_process);
+      break;
+    case MQTT_EVENT_DISCONNECTED:
+      process_poll(&mqtt_client_process);
+      break;
+
+//    case MQTT_EVENT_SUBACK:
+//      break;
+//    case MQTT_EVENT_UNSUBACK:
+//      break;
+//    case MQTT_EVENT_PUBLISH:
+//      break;
+//    case MQTT_EVENT_PUBACK:
+//      break;
+//
+//      /* Errors */
+//    case MQTT_EVENT_ERROR:
+//      break;
+//    case MQTT_EVENT_PROTOCOL_ERROR:
+//      break;
+//    case MQTT_EVENT_CONNECTION_REFUSED_ERROR:
+//      break;
+//    case MQTT_EVENT_DNS_ERROR:
+//      break;
+//    case MQTT_EVENT_NOT_IMPLEMENTED_ERROR:
+//      break;
+    default:
+      PRINTF("APP - Application got a unhandled MQTT event: %i\n", event);
+      break;
+
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+mqtt_status_t
+client_mqtt_register(){
+  mqtt_status_t ret;
+
+  snprintf(client_id, MQTT_CLIENT_ID_LEN, "d:%s:%s:%02x%02x%02x%02x%02x%02x",
+           conf.org_id, conf.type_id,
+           linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
+           linkaddr_node_addr.u8[2], linkaddr_node_addr.u8[5],
+           linkaddr_node_addr.u8[6], linkaddr_node_addr.u8[7]);
+
+  PRINTF("APP attempting to register.\n");
+  ret = mqtt_register(&conn, &mqtt_client_process, client_id,
+      mqtt_event_handler,
+      MQTT_CLIENT_MAX_SEGMENT_SIZE);
+
+  /*
+   * Autoreconnect can bring the connection into a state where the MQTT app
+   * compulsively opens very many sockets.
+   */
+  conn.auto_reconnect = 0;
+  conn.state = MQTT_CONN_STATE_NOT_CONNECTED;
+
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+mqtt_status_t
+client_mqtt_connect(){
+  mqtt_status_t ret = MQTT_STATUS_OK;
+  if (conn.state == MQTT_CONN_STATE_NOT_CONNECTED) {
+    PRINTF("APP attempting to connect.\n");
+    ret = mqtt_connect(&conn,
+        conf.host, conf.port, conf.publish_interval * 3);
+  }
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+static void
+construct_message(mqtt_client_message* msg){
+  static int seq_no = 0;
+
+  seq_no++;
+
+  msg->id = seq_no;
+
+  snprintf(msg->topic, MQTT_CLIENT_TOPIC_LEN, "iot-2/evt/status/fmt/json");
+
+  int size = snprintf((char *)(msg->payload), MQTT_CLIENT_PAYLOAD_LEN,
+      "{\"d\": {"
+      "\"board_string\": \"%s\","
+      "\"seq_no\": %u,"
+      "\"uptime\": %lu"
+      "}}",
+      BOARD_STRING,
+      seq_no,
+      clock_seconds()
+      );
+  if(size >= MQTT_CLIENT_PAYLOAD_LEN){
+    PRINTF("MQTT_CLIENT_PAYLOAD_LEN is too small!");
+  }
+
+  msg->size = size;
+}
+/*---------------------------------------------------------------------------*/
+mqtt_status_t
+client_mqtt_publish(){
+
+  mqtt_status_t ret = MQTT_STATUS_OK;
+
+  /*
+   * Quick successive publishes can lock up the MQTT process, so we check
+   * whether the previous message is fully out the door first.
+   */
+  if (conn.state == MQTT_CONN_STATE_CONNECTED_TO_BROKER &&
+      !(conn.out_queue_full || !conn.out_buffer_sent)) {
+    construct_message(&msg);
+    ret = mqtt_publish(&conn, &msg.id, msg.topic, msg.payload, msg.size,
+        MQTT_QOS_LEVEL_0, MQTT_RETAIN_OFF);
+  }
+
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(mqtt_client_process, ev, data)
+{
+  static struct etimer publish_periodic_timer;
+
+  PROCESS_BEGIN();
+
+  PRINTF("APP Process waiting.\n");
+
+  /* Wait until we connect to the RPL DAG. */
+  while (rpl_get_any_dag() == (rpl_dag_t *)NULL){
+    etimer_set(&publish_periodic_timer, CLOCK_SECOND);
+    PROCESS_YIELD();
+  }
+  etimer_stop(&publish_periodic_timer);
+
+  PRINTF("APP Process started.\n");
+  client_mqtt_register();
+  client_mqtt_connect();
+
+  while(1) {
+
+    PROCESS_YIELD();
+
+    /* MQTT event handler got an event from the MQTT app. */
+    if(ev == PROCESS_EVENT_POLL){
+      if (conn.state == MQTT_CONN_STATE_CONNECTED_TO_BROKER){
+        etimer_set(&publish_periodic_timer, conf.publish_interval *
+        CLOCK_SECOND);
+      } else {
+        /* If disconnected, try reconnecting. */
+        etimer_stop(&publish_periodic_timer);
+        client_mqtt_connect();
+      }
+    }
+
+    if (ev == PROCESS_EVENT_TIMER && data == &publish_periodic_timer) {
+      client_mqtt_publish();
+      etimer_restart(&publish_periodic_timer);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/coua/mqtt-client/mqtt-client.h
+++ b/examples/coua/mqtt-client/mqtt-client.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  char* host;
+  uint16_t port;
+  uint16_t publish_interval;
+  char org_id[MQTT_CLIENT_CONFIG_ORG_ID_LEN];
+  char type_id[MQTT_CLIENT_CONFIG_TYPE_ID_LEN];
+
+} mqtt_configuration;
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  uint16_t id;
+  char topic[MQTT_CLIENT_TOPIC_LEN];
+  uint8_t payload[MQTT_CLIENT_PAYLOAD_LEN];
+  uint32_t size;
+} mqtt_client_message;
+/*---------------------------------------------------------------------------*/
+PROCESS(mqtt_client_process, "MQTT Client");
+/*---------------------------------------------------------------------------*/
+

--- a/examples/coua/mqtt-client/project-conf.h
+++ b/examples/coua/mqtt-client/project-conf.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/* Basic RPL configuration */
+#define IEEE802154_CONF_PANID                   0xABCD
+#define RF_CORE_CONF_CHANNEL                    25
+/*---------------------------------------------------------------------------*/
+/* Configuration of the MQTT broker */
+//#define MQTT_BROKER_IP                          "0000:0000:0000:0000:0000:ffff:c0a8:6401" //localhost
+#define MQTT_BROKER_IP                          "0000:0000:0000:0000:0000:ffff:b8ac:7cbd" // IBM
+//#define MQTT_BROKER_IP                          "0000:0000:0000:0000:0000:ffff:ac11:0001" //docker
+//#define MQTT_BROKER_IP                          "fd00:0000:0000:0000:0000:0000:0000:0001" //Slip
+//#define MQTT_BROKER_PORT                        50000
+#define MQTT_BROKER_PORT                        1883
+/*---------------------------------------------------------------------------*/
+/* Configuration of the MQTT app. */
+#define MQTT_CLIENT_MAX_SEGMENT_SIZE            128
+/*---------------------------------------------------------------------------*/
+/* Configuration of the MQTT messages, buffer sizes, etc. */
+#define MQTT_PUBLISH_INTERVAL                   10
+#define MQTT_CLIENT_TOPIC_LEN                   26
+#define MQTT_CLIENT_PAYLOAD_LEN                 127
+#define MQTT_CLIENT_CONFIG_ORG_ID_LEN           11
+#define MQTT_CLIENT_DEFAULT_ORG_ID              "quickstart"
+#define MQTT_CLIENT_CONFIG_TYPE_ID_LEN          5
+#define MQTT_CLIENT_DEFAULT_TYPE_ID             "coua"
+/*
+ * The format is "d:<org_id>:<type_id>:<device_id>". Counting the 'd', three
+ * colons, the twelve character device ID and the terminating \0 gives 17.
+ */
+#define MQTT_CLIENT_ID_LEN                      MQTT_CLIENT_CONFIG_ORG_ID_LEN + MQTT_CLIENT_CONFIG_TYPE_ID_LEN + 17
+
+
+
+#define UIP_CONF_BUFFER_SIZE                    900
+#define NBR_TABLE_CONF_MAX_NEIGHBORS            5
+#define UIP_CONF_MAX_ROUTES                     5
+#define UIP_CONF_TCP_MSS                        128
+#define UIP_CONF_ND6_RETRANS_TIMER  10000
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/examples/sensniff/coua/target-conf.h
+++ b/examples/sensniff/coua/target-conf.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef TARGET_CONF_H_
+#define TARGET_CONF_H_
+/*---------------------------------------------------------------------------*/
+#define CC26XX_UART_CONF_BAUD_RATE    460800
+#define ROM_BOOTLOADER_ENABLE              1
+/*---------------------------------------------------------------------------*/
+#define SENSNIFF_IO_DRIVER_H "pool/cc13xx-cc26xx-io.h"
+/*---------------------------------------------------------------------------*/
+#endif /* TARGET_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/platform/coua/Makefile.coua
+++ b/platform/coua/Makefile.coua
@@ -6,7 +6,7 @@ endif
 
 CONTIKI_TARGET_DIRS = .
 
-CONTIKI_TARGET_SOURCEFILES += contiki-main.c
+CONTIKI_TARGET_SOURCEFILES += contiki-main.c leds-arch.c button-sensor.c coua-sensors.c
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
@@ -25,6 +25,9 @@ endif
 ifndef SMALL
   SMALL = 1
 endif
+
+### Signal that we can be programmed with cc2538-bsl
+BOARD_SUPPORTS_BSL=1
 
 ### Define the CPU directory
 CPU_FAMILY = cc13xx

--- a/platform/coua/Makefile.coua
+++ b/platform/coua/Makefile.coua
@@ -1,0 +1,36 @@
+#  platform makefile
+
+ifndef CONTIKI
+  $(error CONTIKI not defined! You must specify where CONTIKI resides)
+endif
+
+CONTIKI_TARGET_DIRS = .
+
+CONTIKI_TARGET_SOURCEFILES += contiki-main.c
+
+CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
+
+CLEAN += *.coua
+
+# We define WITH_SLIP to notify various software modules that we use SLIP
+ifeq ($(WITH_SLIP),1)
+  $(info Building with SLIP support ENABLED)
+    DEFINES += WITH_SLIP=1
+else
+  $(info Building with SLIP support DISABLED)
+    DEFINES += WITH_SLIP=0
+endif
+
+### Unless the example dictates otherwise, build with code size optimisations
+ifndef SMALL
+  SMALL = 1
+endif
+
+### Define the CPU directory
+CPU_FAMILY = cc13xx
+CONTIKI_CPU=$(CONTIKI)/cpu/cc26xx-cc13xx
+include $(CONTIKI_CPU)/Makefile.$(CPU_FAMILY)
+
+MODULES += core/net core/net/mac \
+           core/net/mac/contikimac \
+           core/net/llsec 

--- a/platform/coua/README.md
+++ b/platform/coua/README.md
@@ -1,0 +1,434 @@
+Getting Started with Contiki on the Weptech Coua
+================================================
+
+This guide aims to get you started with Contiki and the Weptech Coua development
+board.
+
+Coua features
+================
+The Coua features the following components: 
+ * A Texas Instruments CC1310 Cortex®- M3 Microcontroller with 128KB Flash +
+   20KB RAM and an integrated Sub-GHz radio core. Antennas can be connected via
+   U.FL or SMA (assembly variant).
+ * A FTDI FT234XD USB-to-UART converter providing a virtual COM port to the host
+   system.
+ * A reset button.
+ * An ARM 20 pin JTAG connector.
+ * Breakout headers to connect GPIO peripherals.
+
+The CC1310 SoC at the core of the Coua offers the following key
+features:
+
+ * Deep Sleep support with RAM retention for ultra-low energy consumption.
+ * Standard Cortex M3 peripherals (NVIC, SCB, SysTick)
+ * Sleep Timer (underpins rtimers)
+ * SysTick (underpins the platform clock and Contiki's timers infrastructure)
+ * UART, I2C, SPI
+ * Watchdog (in watchdog mode)
+ * uDMA Controller for increased performance (RAM to/from RF)
+ * Random number generator
+ * Low Power Modes
+ * General-Purpose Timers. NB: GPT0 is in use by the platform code, the
+   remaining GPTs are available for application development.
+
+Requirements
+============
+To get started with the Coua, you will need the following:
+
+ * A toolchain to compile Contiki for the CC1310.
+ * Maybe additional drivers so that your OS can communicate with your hardware.
+ * Software to upload images to the CC1310.
+ * Ideally, a JTAG interface that you can use to program your device. The device
+   per se does support loading firmware via USB, but only if the previously
+   installed firmware allows it and if you connect some additional hardware that
+   can signal that you'd like the device to boot into bootloader mode, like a
+   switch, button, or pin header for a jumper. There are single-purpose JTAG
+   interfaces like the Segger J-Link EDU, but also development boards like the
+   TI SmartRF06 that expose their JTAG interface so that you can use them to
+   program the Coua.
+
+This guide was tested on Ubuntu Linux 16.04.
+
+Install a Toolchain
+-------------------
+The toolchain used to build contiki is arm-gcc, also used by other arm-based 
+Contiki ports. If you are using Instant Contiki or the Weptech VM, you will have
+a version pre-installed in your system. To find out if this is the case, try
+this:
+
+    $ arm-none-eabi-gcc -v
+    Using built-in specs.
+    Target: arm-none-eabi
+    Configured with: /scratch/julian/lite-respin/eabi/src/gcc-4.3/configure
+    ...
+    (skip)
+    ...
+    Thread model: single
+    gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
+
+The platform is currently being used/tested with the following toolchains:
+
+* GNU Tools for ARM Embedded Processors. This is the recommended version.
+  <https://launchpad.net/gcc-arm-embedded>
+* Alternatively, you can use this older version for Linux. At the time of 
+  writing, this is the version used by Contiki's regression tests. 
+  <https://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2>
+
+Drivers
+-------
+On Windows, the drivers for the FTDI234 USB chip on the Coua will be
+installed along with [smart-rf-flashprog](TI Flash Programmer 2). You can also
+install these drivers directly from [ftdidrivers](FTDI).
+
+On Linux, the ftdi\_sio kernel module works out of the box. You should see a
+ttyUSB file under /dev as soon as you plug in the Coua.
+
+Flashing your device
+--------------------
+After you have everything set up and compiled your firmware, you will need to
+flash it onto the hardware in order to run it.
+
+### Using a JTAG Interface like TI SmartRF06 + Uniflash
+The CC1310's JTAG interface is exposed via the 20-pin header X5. Most ARM JTAG
+debuggers, like the Segger J-Link EDU, feature that same header. Also some
+development boards with JTAG debuggers on board, like the TI SmartRF06, expose
+that header so you can use them to program your Coua board. This example
+continues with the SmartRF06. Connect the header X5 on the Coua and the header
+labelled "20-pin ARM JTAG Connector" on the SmartRF06 using an applicable cable
+anmd paying close attention to the Pin1 markers.
+
+On the SmartRF board, make sure that the jumpers "VDD to EM" and "Enable UART
+over XDS100v3" are on, and the power source switch is set to USB. Disconnect the
+Coua from USB. Connect the SRF06 to your computer and turn the board on.
+
+You can use TI's [Flash Programmer 2](smart-rf-flashprog) or [Uniflash](uniflash)
+programs to flash the device.  These instructions continue with Uniflash, but
+finding the corresponding settings in Flash Programmer 2 should be
+straightforward.
+
+Select "CC1310F128" as your device and "Texas Instruments XDS100v3 USB Debug
+Probe" as your connection. As your flash image, either select the .bin image of
+your firmware and check the "Binary" checkbox, or select the .hex image and
+leave the "Binary" checkbox unchecked. If using the binary image, make sure the
+load address is set to 0x00. On the Settings tab, make sure that "Erase" is set
+to "Entire Flash". Back on the Program tab, click on "Load Image". The console
+at the bottom should tell you that everything went alright. To make sure, verify
+the image by pressing "Verify Image".
+
+Examples
+========
+Under `examples/coua` you will find the following examples.
+
+mqtt-client
+-----------
+This example shows how to use Contiki's own mqtt app to send data to a MQTT
+broker. The server that the Coua will send its MQTT messages to is IBM's
+Internet of Things Quickstart Server per default, but you may adapt it to send
+data to a server of your choice.
+
+### Preparing a border router
+This example expects a second 6LoWPAN device to act as a RPL border router with
+both access to the RPL DAG via Sub-GHz 6LoWPAN and to the broader internet via
+ethernet or SLIP. You can use the Weptech Saker with it's `ip64-border-router`
+example firmware (refer to the Saker's README.md), or a different device, like a
+second Coua board, running the `ipv6/rpl-border-router` example with SLIP. How
+to run that example on the Coua will be described further down.
+
+### Preparing the Coua
+The example code is under `examples/coua/mqtt-client`.
+
+#### Prepare the code
+Configure the example.
+1. In `project-conf.h`, configure the RPL to match your border router's
+configuration by setting the correct PAN ID and RF Channel. Most border router
+examples use the given default, so they should work out of the box.
+2. Also in `project-conf.h`, configure the MQTT Client. You can set the IP and
+port of the MQTT broker as well as the interval in which messages are generated.
+The IP for the IBM Watson IoT platform is preconfigured, but can be set to the
+IP of any computer that runs an MQTT server like Mosquitto.
+The messages that are generated follow the format of IBM's Watson IoT Platform
+as laid out in the [IBM Bluemix Documentation](ibm-bluemix-mqtt). The defines
+that are related to the message generation will only become important once you
+begin adapting the message format for your own application.
+
+#### Compile the Code
+Compile the code by running `make TARGET=coua`. 
+
+#### Flash the Device
+Flash the `mqtt-client.bin` image onto your device with the recipe described
+under [Flashing your device](#flashing-your-device). 
+
+### Running it all
+Once the Coua and the border router are ready, run it all by connecting them to
+USB to power them up (make sure the JTAG interface is disconnected). Check the
+`printf` output of the devices using a serial program like `minicom` or `hterm`.
+For both our example and the border router example firmwares, the serial
+consoles are preconfigured for 8 data bits, 1 Stop bit, no parity at 115200
+baud.
+The Coua should now connect to your MQTT Server of choice and begin transmitting
+data.
+
+#### Viewing the data on a Mosquitto Server
+If you are running your own Mosquitto server, you can connect to it with
+the `mosquitto_sub` command by subscribing to the topic
+`iot-2/evt/status/fmt/json`. This example is for a server running on localhost,
+port 50000:
+> mosquitto\_sub -h localhost -p 50000 -t iot-2/evt/status/fmt/json
+
+
+#### Viewing the data on IBM Watson IoT Platform
+You can see the way the IBM device IDs are constructed in
+`client_mqtt_connect()` in `mqtt-client.c`. The client ID is constructed of the
+org\_id and type\_id that you can configure in `project-conf.h`, and the device
+ID that is constructed from the Coua's MAC address' first three and last three
+bytes, in hexadecimal, without colons. The Coua will print its MAC address on
+startup: 
+
+>  Link layer addr: 00:12:4b:00:09:a1:b1:42
+
+Therefore, the device ID for that device will be `00124ba1b142`.
+
+With your device ID, check out the data that the MQTT server has received by
+going to <https://quickstart.internetofthings.ibmcloud.com>. 
+
+IPV6/rpl-border-router
+----------------------
+The border router example under `examples/ipv6/rpl-border-router` can be
+compiled for the Coua as is. Just run `make TARGET=coua`, flash the
+`border-router.bin` image onto your device and connect it to your computer. The
+connection to the broader internet is made via SLIP which requires the
+`tunslip6` program running on your computer. It can be found under `tools/` and
+compiled by running `make tunslip6`. The resulting `tunslip6` binary can be
+started by running `sudo ./tunslip6 fd00::1/64`. The specified address range
+will be used by the RPL to allocate IP addresses.
+
+Sensniff
+--------
+The Saker can be programmed to act as a sniffer to record wireless 802.15.4
+communications using [Sensniff](https://github.com/g-oikonomou/sensniff). The
+firmware code is available in Contiki under `examples/sensniff`.
+
+### Prepare the code
+In `target-conf.h` under `examples/sensniff/coua`, take note of the
+`UART0_CONF_BAUD_RATE`, which is set to 460800 by default.
+
+### Compile and flash the firmware
+Compile the sniffer firmware by running `make TARGET=coua` and
+flash it on the Saker using one of the recipes under [Flashing your
+device](#flashing-your-device).
+
+### Run the host tool
+The host tool is available from Github, see above. Check out that repository and
+read its `README.md`. You can run the host tool by running 
+`python sensniff.py -b 460800 -d /dev/ttyUSBX`, exchanging `USBX` for whatever 
+port where your Saker is connected. The host tool should report 
+`Sniffing in channel: 0`. Make sure to use the baud rate that is configured in
+`target-conf.h` as the `-b` parameter. 
+
+A list of available commands will be printed when starting the tool or when you
+type `h` or `?`. There are commands available to set the channel in which you
+want to sniff.
+
+### Run wireshark
+Open the FIFO `/tmp/sensniff` in wireshark by running `wireshark -k -i
+/tmp/sensniff`. Packets in the configured channel should appear. 
+
+Advanced Topics
+===============
+The platform's functionality can be customised by tweaking the various
+configuration directives in `platform/coua/contiki-conf.h`. Bear in
+mind that defines specified in `contiki-conf.h` can be over-written by defines
+specified in `project-conf.h`, which is a file commonly encountered in example
+directories.
+
+Thus, if you want to modify the platform's default behaviour, change values in
+`contiki-conf.h`. If you want to configure custom behaviour for a specific
+example, modify this example's `project-conf.h`. If you have any changes that
+you think would be good global defaults, we would love to hear from you on
+[Github](https://github.com/Weptech_elektronik).
+
+> Note: Some defines in `contiki-conf.h` are not meant to be modified.
+
+Using the Serial Bootloader
+---------------------------
+If the device is configured correctly and extended with some additional
+hardware, it is possible to start the device in bootloader mode. It is then
+possible to load firmware onto the device using the `cc2538-bsl.py` python
+script that ships with contiki under tools/cc2538-bsl. In the platforms
+`Makefile`, there is an `%.upload` target, so that you can then compile and
+flash the device with one convenient console command like 
+`make TARGET=coua mqtt-client.bin mqtt-client.upload`.
+
+You need the possibility to externally pull a DIO pin high or low. As an
+example, we have attached a push button and a small circuit that will pull DIO9,
+which is the third pin on the header X1, low if pressed. Other possible
+solutions would be a jumper over pins 2 and 3 of header X1, which pulls DIO9
+high (second pin on X1 is VDD).
+
+Once your hardware modifications are done, set `ROM_BOOTLOADER_ENABLE` to 1 in
+`platform/coua/contiki-conf.h`. Addtionally, configure the bootloader in
+`board.h` by setting the macros `SET_CCFG_BL_CONFIG_*`. They are wrapped in a
+conditional statement that sets sane defaults if `ROM_BOOTLOADER_ENABLE` is 0.
+Here are the values that we used for the DIO9-pulled-low button:
+
+	#define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0xC5
+	#define SET_CCFG_BL_CONFIG_BL_LEVEL                     0x00
+	#define SET_CCFG_BL_CONFIG_BL_PIN_NUMBER                IOID_9
+	#define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xC5
+
+The values `0xC5` are magic numbers that enable the bootloader, where
+`SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE` enables the bootloader per se while
+`SET_CCFG_BL_CONFIG_BL_ENABLE` enables the backdoor to actually start it, so
+both are necessary. `SET_CCFG_BL_CONFIG_BL_PIN_NUMBER` defines the DIO which
+triggers the bootloader backdoor. `SET_CCFG_BL_CONFIG_BL_LEVEL` sets the level
+on which the bootloader is started, 0 for low, 1 for high.
+
+To start the bootloader mode, connect the device to your computer via USB, then
+reset the device while holding down the button.
+
+Then, flash the firmware on your device by running
+    python cc2538-bsl.py -e -w -v path/to/image.bin
+The given parameters instruct the script to erase the entire flash, write the
+given image, and verify whether writing succeeded.
+
+Please note that this script uses the .bin image that will be produced by the
+compilation along with numerous others.
+
+Node IEEE/RIME/IPv6 Addresses
+-----------------------------
+Nodes will generally autoconfigure their IPv6 address based on their IEEE
+address. The IEEE address can be read directly from the CC2538 Info Page, or it
+can be hard-coded. Additionally, the user may specify a 2-byte value at build
+time, which will be used as the IEEE address' 2 LSBs.
+
+To configure the IEEE address source location (Info Page or hard-coded), use the
+`IEEE_ADDR_CONF_HARDCODED` define in contiki-conf.h:
+
+* 0: Info Page
+* 1: Hard-coded
+
+If `IEEE_ADDR_CONF_HARDCODED` is defined as 1, the IEEE address will take its
+value from the `IEEE_ADDR_CONF_ADDRESS` define. If `IEEE_ADDR_CONF_HARDCODED` is
+defined as 0, the IEEE address can come from either the primary or secondary
+location in the Info Page. To use the secondary address, define
+`IEEE_ADDR_CONF_USE_SECONDARY_LOCATION` as 1.
+
+Additionally, you can override the IEEE's 2 LSBs, by using the `NODEID` make
+variable. The value of `NODEID` will become the value of the `IEEE_ADDR_NODE_ID`
+pre-processor define. If `NODEID` is not defined, `IEEE_ADDR_NODE_ID` will not
+get defined either. For example:
+
+    make NODEID=0x79ab
+
+This will result in the 2 last bytes of the IEEE address getting set to 0x79
+0xAB.
+
+UART Baud Rate
+--------------
+By default, the CC1310 UART is configured with a baud rate of 115200. It is easy
+to increase this to 230400 by changing the value of `CC26XX_UART_CONF_BAUD_RATE`
+in `contiki-conf.h` or `project-conf.h`.
+
+    #define CC26XX_UART_CONF_BAUD_RATE 230400
+
+Low-Power Modes
+---------------
+The platform takes advantage of the CC1310's power saving features. There are
+function calls to the LPM code in `main\(\)` as well as the `transmit\(\)`
+routines that put the chip in some low power mode between servicable events or
+while the RF core handles a transmission.
+
+The LPM code allows the registration of modules at runtime that get called when
+the CPU wants to enter a low power mode, shuts down, or wakes back up. With
+these functions, modules can prevent dropping to a power mode that they deem too
+low for their operation, request power domains to be left powered on during
+deep sleep, prepare for a deep sleep or shutdown, or reconfigure themselves
+after a deep sleep. See `cc26xx-uart.c` for an example LPM module. There you
+can also see that the `domain\_lock` variable can be set and unset at runtime.
+
+There are three low power modes, "sleep", called "idle" in the CC1310 reference
+manual, "deep sleep", called "standby" in the manual, and "shutdown". In sleep
+mode, the CPU is shut down, but most other peripherals stay powered on and can
+wake up the CPU. In deep sleep, the CPU as well as every power domain that has
+not been explicitly locked by an LPM module will be powered down. The regular
+sleep phases in `main\(\)` will either drop to sleep or deep sleep.
+
+To determine which power mode to use, the following logic is followed:
+
+* The deepest available low power mode can be hard-coded by using
+  the `LPM_MODE_MAX_SUPPORTED` macro in the LPM driver (`lpm.[ch]`). Thus, it
+  is possible to prohibit deep sleep altogether.
+* Code modules which are affected by low power operation can 'register'
+  themselves with the LPM driver.
+* If the projected low-power duration is lower than `STANDBY_MIN_DURATION`,
+  the chip will simply sleep.
+* If the projected low power duration is sufficiently long, the LPM will visit
+  all registered modules to query the maximum allowed power mode (maximum means
+  sleep vs deep sleep in this context). It will then drop to this power mode.
+  This is where a code module can forbid deep sleep if required.
+* All registered modules will be notified when the chip is about to enter
+  deep sleep, as well as after wake-up.
+
+When the chip does enter deep sleep:
+
+* The RF Core, VIMS, SYSBUS and CPU power domains are always turned off. Due to
+  the way the RF driver works, the RFCORE PD should be off already.
+* Peripheral clocks stop
+* The Serial and Peripheral power domains are turned off, unless an LPM module
+  requests them to stay operational. For example, the net-uart demo keeps the
+  serial power domain powered on and the UART clocked under sleep and deep
+  sleep in order to retain UART RX functionality.
+* If both SERIAL and PERIPH PDs are turned off, we also switch power source to
+  the uLDO for ultra low leakage under deep sleep.
+
+The chip will come out of low power mode by one of the following events:
+
+* Button press or, in the case of the SensorTag, a reed relay trigger
+* Software clock tick (timer). The clock ticks at 128Hz, therefore the maximum
+  time we will ever spend in a sleep mode is 7.8125ms. In hardware terms, this
+  is an AON RTC Channel 2 compare interrupt.
+* Rtimer triggers, as part of ContikiMAC's sleep/wake-up cycles. The rtimer
+  sits on the AON RTC channel 0.
+
+Shutdown can be entered by explicitly calling `lpm\_shutdown\(\)`. All LPM
+modules that registered an according function are then notified and get the
+chance to clean up. Shutdown can not be prevented by the modules. The call to
+`lpm_shutdown\(\)` may register a wakeup pin with which the system can be called
+from shutdown. The I/O pins are latched to retain their values during shutdown.
+The system is then powered off completely, so that apart from the wakeup pin and
+the retainment of I/O values, shutdown is indistinguishable from holding the
+system in reset.
+
+Code Size Optimisations
+-----------------------
+The build system currently uses optimization level `-Os`, which is controlled
+indirectly through the value of the `SMALL` make variable. This value can be
+overridden by example makefiles, or it can be changed directly in
+`platform/coua/Makefile.coua`.
+
+Historically, the `-Os` flag has caused problems with some toolchains. If you
+are using one of the toolchains documented in this README, you should be able to
+use it without issues. If for whatever reason you do come across problems, try
+setting `SMALL=0` or replacing `-Os` with `-O2` in
+`cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx`.
+
+Doxygen Documentation
+=====================
+This port's code has been documented with doxygen. To build the documentation,
+navigate to `$(CONTIKI)/doc` and run `make`. This will build the entire contiki
+documentation and may take a while.
+
+If you want to build this platform's documentation only and skip the remaining
+platforms, run this:
+
+    make basedirs="platform/coua core cpu/cc26xx-cc13xx examples/coua"
+
+Once you've built the docs, open `$(CONTIKI)/doc/html/index.html` and enjoy.
+
+[smart-rf-studio]: http://www.ti.com/tool/smartrftm-studio "SmartRF Studio"
+[smart-rf-flashprog]: http://www.ti.com/tool/flash-programmer "SmartRF Flash Programmer"
+[uniflash]: http://processors.wiki.ti.com/index.php/Category:CCS_UniFlash "UniFlash"
+[manual]: https://www.weptech.de/6LoWPAN_IoT_Gateway_EN.html?file=files/site/6LoWPAN-IoT-Gateway/6LoWPAN-IoT-Gateway_Manual_v1.4.pdf "Manual"
+[ftdidrivers]:http://www.ftdichip.com/FTDrivers.htm
+[ibm-bluemix-mqtt]:https://console.ng.bluemix.net/docs/services/IoT/devices/mqtt.html
+

--- a/platform/coua/board.h
+++ b/platform/coua/board.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \addtogroup coua
+ *
+ * @{
+ *
+ * \defgroup coua-board Board Definitions
+ *
+ * This file provides connectivity information on LEDs, UARTs, etc.
+ *
+ * @{
+ *
+ * \file
+ *      Header file with definitions related to the I/O connections
+ *
+ * \note Do not include this file directly. It gets included by contiki-conf.h
+ *       after all relevant directives have been set.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+/*---------------------------------------------------------------------------*/
+/**
+ * \name LED configuration
+ * @{
+ */
+/*---------------------------------------------------------------------------*/
+/* Some files include leds.h before us, so we need to get rid of defaults in
+ * leds.h before we provide correct definitions */
+#undef LEDS_GREEN
+#undef LEDS_YELLOW
+#undef LEDS_RED
+#undef LEDS_CONF_ALL
+
+
+/* Notify various examples that we have no LEDs */
+#define PLATFORM_HAS_LEDS               0
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name UART configuration
+ *
+ * @{
+ */
+#define BOARD_IOID_UART_RX                      IOID_1
+#define BOARD_IOID_UART_TX                      IOID_2
+#define BOARD_IOID_UART_RTS                     IOID_0
+#define BOARD_IOID_UART_CTS                     IOID_5
+#define BOARD_UART_RX             (1 << BOARD_IOID_UART_RX)
+#define BOARD_UART_TX             (1 << BOARD_IOID_UART_TX)
+#define BOARD_UART_RTS            (1 << BOARD_IOID_UART_RTS)
+#define BOARD_UART_CTS            (1 << BOARD_IOID_UART_CTS)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Bootloader configuration
+ *
+ * @{
+ */
+#if ROM_BOOTLOADER_ENABLE
+#define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0xC5
+#define SET_CCFG_BL_CONFIG_BL_LEVEL                     0x00
+#define SET_CCFG_BL_CONFIG_BL_PIN_NUMBER                IOID_9
+#define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xC5
+#else
+#define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0x00
+#define SET_CCFG_BL_CONFIG_BL_LEVEL                     0x01
+#define SET_CCFG_BL_CONFIG_BL_PIN_NUMBER                0xFF
+#define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xFF
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Device string used on startup
+ * @{
+ */
+#define BOARD_STRING                    "Coua"
+/** @} */
+/*---------------------------------------------------------------------------*/
+#endif /* BOARD_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/platform/coua/board.h
+++ b/platform/coua/board.h
@@ -52,6 +52,8 @@
 
 #ifndef BOARD_H_
 #define BOARD_H_
+
+#include "ioc.h"
 /*---------------------------------------------------------------------------*/
 /**
  * \name LED configuration
@@ -65,9 +67,35 @@
 #undef LEDS_RED
 #undef LEDS_CONF_ALL
 
+#define LEDS_YELLOW                     1
+#define LEDS_RED                        LEDS_YELLOW
+#define LEDS_GREEN                      LEDS_YELLOW
+#define LEDS_ORANGE                     LEDS_YELLOW
+#define LEDS_CONF_ALL                   LEDS_YELLOW
 
-/* Notify various examples that we have no LEDs */
-#define PLATFORM_HAS_LEDS               0
+
+/* Notify various examples that we have LEDs */
+#define PLATFORM_HAS_LEDS               1
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name LED IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_LED            IOID_8
+#define BOARD_LED                 (1 << BOARD_IOID_LED)
+#define BOARD_LED_ALL             (BOARD_LED)
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Button IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_KEY          IOID_9
+#define BOARD_KEY               (1 << BOARD_IOID_KEY)
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/coua/button-sensor.c
+++ b/platform/coua/button-sensor.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup coua-button-sensor
+ * @{
+ *
+ * \file
+ *      Driver for Coua buttons
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "lib/sensors.h"
+#include "dev/button-sensor.h"
+#include "gpio-interrupt.h"
+#include "sys/timer.h"
+#include "lpm.h"
+
+#include "ti-lib.h"
+
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+#define BUTTON_GPIO_CFG         (IOC_CURRENT_2MA  | IOC_STRENGTH_AUTO | \
+                                 IOC_IOPULL_UP    | IOC_SLEW_DISABLE  | \
+                                 IOC_HYST_DISABLE | IOC_BOTH_EDGES    | \
+                                 IOC_INT_ENABLE   | IOC_IOMODE_NORMAL | \
+                                 IOC_NO_WAKE_UP   | IOC_INPUT_ENABLE)
+/*---------------------------------------------------------------------------*/
+#define DEBOUNCE_DURATION (CLOCK_SECOND >> 5)
+
+struct btn_timer {
+  struct timer debounce;
+  clock_time_t start;
+  clock_time_t duration;
+};
+
+static struct btn_timer timer;
+/*---------------------------------------------------------------------------*/
+static void
+button_press_handler()
+{
+    if(!timer_expired(&timer.debounce)) {
+      return;
+    }
+
+    timer_set(&timer.debounce, DEBOUNCE_DURATION);
+
+    /*
+     * Start press duration counter on press (falling), notify on release
+     * (rising)
+     */
+    if(ti_lib_gpio_read_dio(BOARD_IOID_KEY) == 0) {
+      timer.start = clock_time();
+      timer.duration = 0;
+    } else {
+      timer.duration = clock_time() - timer.start;
+      sensors_changed(&button_sensor);
+    }
+}
+/*---------------------------------------------------------------------------*/
+int
+config(int type, int c)
+{
+  switch(type) {
+  case SENSORS_HW_INIT:
+    ti_lib_gpio_clear_event_dio(BOARD_IOID_KEY);
+    ti_lib_rom_ioc_pin_type_gpio_input(BOARD_IOID_KEY);
+    ti_lib_rom_ioc_port_configure_set(BOARD_IOID_KEY, IOC_PORT_GPIO, BUTTON_GPIO_CFG);
+    gpio_interrupt_register_handler(BOARD_IOID_KEY, button_press_handler);
+    break;
+  case SENSORS_ACTIVE:
+    if(c) {
+      ti_lib_gpio_clear_event_dio(BOARD_IOID_KEY);
+      ti_lib_rom_ioc_pin_type_gpio_input(BOARD_IOID_KEY);
+      ti_lib_rom_ioc_port_configure_set(BOARD_IOID_KEY, IOC_PORT_GPIO, BUTTON_GPIO_CFG);
+      ti_lib_rom_ioc_int_enable(BOARD_IOID_KEY);
+    } else {
+      ti_lib_rom_ioc_int_disable(BOARD_IOID_KEY);
+    }
+    break;
+  default:
+    break;
+  }
+
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+int
+status(int type)
+{
+  switch(type) {
+  case SENSORS_ACTIVE:
+  case SENSORS_READY:
+    if(ti_lib_rom_ioc_port_configure_get(BOARD_IOID_KEY) & IOC_INT_ENABLE) {
+      return 1;
+    }
+    break;
+  default:
+    break;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+int
+value(int type)
+{
+    return ti_lib_gpio_read_dio(BOARD_IOID_KEY) == 0 ? 1 : 0;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(button_sensor, BUTTON_SENSOR, value, config, status);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/coua/contiki-conf.h
+++ b/platform/coua/contiki-conf.h
@@ -85,7 +85,7 @@ typedef uint32_t rtimer_clock_t;
  * @{
  */
 #ifndef ROM_BOOTLOADER_ENABLE
-#define ROM_BOOTLOADER_ENABLE              0
+#define ROM_BOOTLOADER_ENABLE              1
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/

--- a/platform/coua/contiki-conf.h
+++ b/platform/coua/contiki-conf.h
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \addtogroup coua
+ * @{
+ *
+ * \file
+ *      Configuration for the Coua platform
+ */
+#ifndef CONTIKI_CONF_H
+#define CONTIKI_CONF_H
+
+#include <stdint.h>
+
+/*---------------------------------------------------------------------------*/
+/* Include project specific configuration file */
+#ifdef PROJECT_CONF_H
+#include PROJECT_CONF_H
+#endif /* PROJECT_CONF_H */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Compiler configuration and platform-specific type definitions
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define CLOCK_CONF_SECOND 128
+
+/* Compiler configurations */
+#define CCIF
+#define CLIF
+
+/* Platform typedefs */
+typedef uint32_t clock_time_t;
+typedef uint32_t uip_stats_t;
+
+/*
+ * rtimer.h typedefs rtimer_clock_t as unsigned short. We need to define
+ * RTIMER_CLOCK_DIFF to override this
+ */
+typedef uint32_t rtimer_clock_t;
+#define RTIMER_CLOCK_DIFF(a, b)     ((int32_t)((a) - (b)))
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name ROM Bootloader configuration
+ *
+ * Per se, the board supports the serial bootloader, but has no buttons to boot
+ * the CPU into bootloader mode. You can, however, solder on pin headers and use
+ * a jumper to indicate when you want to boot into bootloader mode. Then, set
+ * this to 1 and configure your jumper in board.h.
+ *
+ * @{
+ */
+#ifndef ROM_BOOTLOADER_ENABLE
+#define ROM_BOOTLOADER_ENABLE              0
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Crystal configuration
+ * @{
+ */
+/**
+ * This value is used to mitigate load capacitances of the external 24MHz
+ * crystal that is used by the radio core.
+ */
+#define SET_CCFG_MODE_CONF_XOSC_CAPARRAY_DELTA  0xF4
+#define SET_CCFG_MODE_CONF_XOSC_CAP_MOD         0
+/**
+ * If this is set, the systems keeps the HF crystal oscillator on even when the
+ * radio is off, reducing the radio startup time.
+ */
+#ifndef CC2650_FAST_RADIO_STARTUP
+#define CC2650_FAST_RADIO_STARTUP               0
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Generic Configuration directives
+ *
+ * @{
+ */
+#ifndef ENERGEST_CONF_ON
+#define ENERGEST_CONF_ON            0 /**< Energest Module */
+#endif
+
+#ifndef STARTUP_CONF_VERBOSE
+#define STARTUP_CONF_VERBOSE        1 /**< Set to 0 to decrease startup verbosity */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Character I/O Configuration
+ *
+ * @{
+ */
+#ifndef CC26XX_UART_CONF_ENABLE
+#define CC26XX_UART_CONF_ENABLE            1 /**< Enable/Disable UART I/O */
+#endif
+
+#ifndef CC26XX_UART_CONF_BAUD_RATE
+#define CC26XX_UART_CONF_BAUD_RATE    115200 /**< Default UART0 baud rate */
+#endif
+
+/* Turn off example-provided putchars */
+#define SLIP_BRIDGE_CONF_NO_PUTCHAR        1
+#define SLIP_RADIO_CONF_NO_PUTCHAR         1
+
+#ifndef SLIP_ARCH_CONF_ENABLED
+/*
+ * Determine whether we need SLIP
+ * This will keep working while UIP_FALLBACK_INTERFACE and CMD_CONF_OUTPUT
+ * keep using SLIP
+ */
+#if defined(UIP_FALLBACK_INTERFACE) || defined(CMD_CONF_OUTPUT)
+#define SLIP_ARCH_CONF_ENABLED             1
+#endif
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/* board.h assumes that basic configuration is done */
+#include "board.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Radio driver selection
+ *
+ * Auto-configure Prop-mode radio unless the project has specified otherwise.
+ * @{
+ */
+#ifndef CC13XX_CONF_PROP_MODE
+#define CC13XX_CONF_PROP_MODE 1
+#endif /* CC13XX_CONF_PROP_MODE */
+
+#if CC13XX_CONF_PROP_MODE
+#define NETSTACK_CONF_RADIO                     prop_mode_driver
+#else
+#define NETSTACK_CONF_RADIO                     ieee_mode_driver
+#endif
+
+#ifndef IEEE_MODE_CONF_PROMISCOUS
+#define IEEE_MODE_CONF_PROMISCOUS       0 /**< 1 to enable promiscous mode for the ieee driver. */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Network Stack Configuration
+ *
+ * @{
+ */
+#ifndef IEEE802154_CONF_PANID
+#define IEEE802154_CONF_PANID           0xABCD /**< Default PAN ID */
+#endif
+
+#ifndef RF_CORE_CONF_CHANNEL
+#define RF_CORE_CONF_CHANNEL            25
+#endif
+
+#ifndef NETSTACK_CONF_NETWORK
+#if NETSTACK_CONF_WITH_IPV6
+#define NETSTACK_CONF_NETWORK           sicslowpan_driver
+#else
+#define NETSTACK_CONF_NETWORK           rime_driver
+#endif /* NETSTACK_CONF_WITH_IPV6 */
+#endif /* NETSTACK_CONF_NETWORK */
+
+#ifndef NETSTACK_CONF_MAC
+#define NETSTACK_CONF_MAC               csma_driver
+#endif
+
+#ifndef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC               contikimac_driver
+#endif
+
+#ifndef NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE
+#define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE 8
+#endif
+
+#ifndef NETSTACK_CONF_FRAMER
+#if NETSTACK_CONF_WITH_IPV6
+#define NETSTACK_CONF_FRAMER            framer_802154
+#else /* NETSTACK_CONF_WITH_IPV6 */
+#define NETSTACK_CONF_FRAMER            contikimac_framer
+#endif /* NETSTACK_CONF_WITH_IPV6 */
+#endif /* NETSTACK_CONF_FRAMER */
+
+/*---------------------------------------------------------------------------*/
+/* Configure NullRDC for when it's selected */
+/* Automatically await others people's acks */
+#define NULLRDC_CONF_802154_AUTOACK          1
+
+#if CC13XX_CONF_PROP_MODE
+#define NULLRDC_CONF_ACK_WAIT_TIME           (RTIMER_SECOND / 400)
+#define NULLRDC_CONF_AFTER_ACK_DETECTED_WAIT_TIME (RTIMER_SECOND / 1000)
+#define NULLRDC_CONF_802154_AUTOACK_HW       0
+#define NULLRDC_CONF_SEND_802154_ACK         1
+#else
+#define NULLRDC_CONF_802154_AUTOACK_HW       1
+#define NULLRDC_CONF_SEND_802154_ACK         0
+#ifndef IEEE_MODE_CONF_AUTOACK
+#define IEEE_MODE_CONF_AUTOACK               1 /**< RF H/W generates ACKs */
+#endif
+#endif
+/*---------------------------------------------------------------------------*/
+/* Configure ContikiMAC for when it's selected */
+#define CONTIKIMAC_CONF_WITH_CONTIKIMAC_HEADER  0
+#define CONTIKIMAC_CONF_WITH_PHASE_OPTIMIZATION 0
+#define WITH_FAST_SLEEP                         1
+
+#if CC13XX_CONF_PROP_MODE
+
+/* Default in contikimac.c is fine, just listed for documentation. */
+/* #ifndef CONTIKIMAC_CONF_CYCLE_TIME */
+/* #define CONTIKIMAC_CONF_CYCLE_TIME              RTIMER_ARCH_SECOND/8 */
+/* #endif *//* CONTIKIMAC_CONF_CYCLE_TIME */
+
+#ifndef CONTIKIMAC_CONF_CCA_CHECK_TIME
+#define CONTIKIMAC_CONF_CCA_CHECK_TIME          RTIMER_ARCH_SECOND/1000
+#endif /* CONTIKIMAC_CONF_CCA_CHECK_TIME */
+
+#ifndef CONTIKIMAC_CONF_CCA_SLEEP_TIME
+#define CONTIKIMAC_CONF_CCA_SLEEP_TIME          RTIMER_ARCH_SECOND/140
+#endif /* CONTIKIMAC_CONF_CCA_SLEEP_TIME */
+
+#ifndef CONTIKIMAC_CONF_LISTEN_TIME_AFTER_PACKET_DETECTED
+#define CONTIKIMAC_CONF_LISTEN_TIME_AFTER_PACKET_DETECTED  RTIMER_ARCH_SECOND/20
+#endif /* CONTIKIMAC_CONF_LISTEN_TIME_AFTER_PACKET_DETECTED */
+
+#ifndef CONTIKIMAC_CONF_SEND_SW_ACK
+#define CONTIKIMAC_CONF_SEND_SW_ACK             1
+#endif /* CONTIKIMAC_CONF_SEND_SW_ACK */
+
+#ifndef CONTIKIMAC_CONF_AFTER_ACK_DETECTED_WAIT_TIME
+#define CONTIKIMAC_CONF_AFTER_ACK_DETECTED_WAIT_TIME RTIMER_ARCH_SECOND/400
+#endif /* CONTIKIMAC_CONF_AFTER_ACK_DETECTED_WAIT_TIME */
+
+#ifndef CONTIKIMAC_CONF_INTER_PACKET_INTERVAL
+#define CONTIKIMAC_CONF_INTER_PACKET_INTERVAL   RTIMER_ARCH_SECOND/150
+#endif /* CONTIKIMAC_CONF_INTER_PACKET_INTERVAL */
+
+#ifndef CONTIKIMAC_CONF_INTER_PACKET_DEADLINE
+#define CONTIKIMAC_CONF_INTER_PACKET_DEADLINE   RTIMER_ARCH_SECOND/20
+#endif /* CONTIKIMAC_CONF_INTER_PACKET_DEADLINE */
+
+#ifndef CONTIKIMAC_CONF_GUARD_TIME
+#define CONTIKIMAC_CONF_GUARD_TIME              RTIMER_ARCH_SECOND/12
+#endif /* CONTIKIMAC_CONF_GUARD_TIME */
+
+#ifndef CONTIKIMAC_CONF_MAX_PHASE_STROBE_TIME
+#define CONTIKIMAC_CONF_MAX_PHASE_STROBE_TIME   RTIMER_ARCH_SECOND/10
+#endif /* CONTIKIMAC_CONF_MAX_PHASE_STROBE_TIME */
+#else
+#endif
+
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name IEEE address configuration
+ *
+ * Used to generate our RIME & IPv6 address
+ * @{
+ */
+/**
+ * \brief Location of the IEEE address
+ * 0 => Read from InfoPage,
+ * 1 => Use a hardcoded address, configured by IEEE_ADDR_CONF_ADDRESS
+ */
+#ifndef IEEE_ADDR_CONF_HARDCODED
+#define IEEE_ADDR_CONF_HARDCODED             0
+#endif
+
+/**
+ * \brief The hardcoded IEEE address to be used when IEEE_ADDR_CONF_HARDCODED
+ * is defined as 1
+ */
+#ifndef IEEE_ADDR_CONF_ADDRESS
+#define IEEE_ADDR_CONF_ADDRESS { 0x00, 0x12, 0x4B, 0x00, 0x89, 0xAB, 0xCD, 0xEF }
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name IPv6, RIME and network buffer configuration
+ *
+ * @{
+ */
+/* Don't let contiki-default-conf.h decide if we are an IPv6 build */
+#ifndef NETSTACK_CONF_WITH_IPV6
+#define NETSTACK_CONF_WITH_IPV6              0
+#endif
+
+#if NETSTACK_CONF_WITH_IPV6
+/*---------------------------------------------------------------------------*/
+/* Addresses, Sizes and Interfaces */
+#define LINKADDR_CONF_SIZE                   8
+#define UIP_CONF_LL_802154                   1
+#define UIP_CONF_LLH_LEN                     0
+
+/* The size of the uIP main buffer */
+#ifndef UIP_CONF_BUFFER_SIZE
+#define UIP_CONF_BUFFER_SIZE              1000
+#endif
+
+/* ND and Routing */
+#ifndef UIP_CONF_ROUTER
+#define UIP_CONF_ROUTER                      1
+#endif
+
+#define UIP_CONF_ND6_SEND_RA                 0
+#define UIP_CONF_IP_FORWARD                  0
+#define RPL_CONF_STATS                       0
+
+#define UIP_CONF_ND6_REACHABLE_TIME     600000
+#define UIP_CONF_ND6_RETRANS_TIMER       10000
+
+#ifndef NBR_TABLE_CONF_MAX_NEIGHBORS
+#define NBR_TABLE_CONF_MAX_NEIGHBORS        20
+#endif
+#ifndef UIP_CONF_MAX_ROUTES
+#define UIP_CONF_MAX_ROUTES                 20
+#endif
+
+#ifndef UIP_CONF_TCP
+#define UIP_CONF_TCP                         1
+#endif
+#ifndef UIP_CONF_TCP_MSS
+#define UIP_CONF_TCP_MSS                    64
+#endif
+
+#define UIP_CONF_UDP                         1
+#define UIP_CONF_UDP_CHECKSUMS               1
+#define UIP_CONF_ICMP6                       1
+
+/* 6LoWPAN */
+#define SICSLOWPAN_CONF_COMPRESSION             SICSLOWPAN_COMPRESSION_HC06
+#define SICSLOWPAN_CONF_COMPRESSION_THRESHOLD   63
+#define SICSLOWPAN_CONF_FRAG                    1
+#define SICSLOWPAN_CONF_MAXAGE                  8
+/*---------------------------------------------------------------------------*/
+#else /* NETSTACK_CONF_WITH_IPV6 */
+/* Network setup for non-IPv6 (rime). */
+#define UIP_CONF_IP_FORWARD                  1
+
+#define RIME_CONF_NO_POLITE_ANNOUCEMENTS     0
+
+#endif /* NETSTACK_CONF_WITH_IPV6 */
+/** @} */
+/*---------------------------------------------------------------------------*/
+#endif /* CONTIKI_CONF_H */
+
+/** @} */

--- a/platform/coua/contiki-main.c
+++ b/platform/coua/contiki-main.c
@@ -238,6 +238,7 @@ main(void)
   process_start(&tcpip_process, NULL);
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
+  leds_init();
   process_start(&sensors_process, NULL);
 
   autostart_start(autostart_processes);

--- a/platform/coua/contiki-main.c
+++ b/platform/coua/contiki-main.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup cc26xx-platforms
+ * @{
+ *
+ * \defgroup coua Coua
+ *
+ *  The Coua is a minimalistic dev board that showcases Weptech elektronik's
+ *  6LoWPAN modules. Featuring a JTAG interface, breakout headers and an
+ *  optional SMA antenna jack, it can be used to kickstart your development of
+ *  6LoWPAN devices.
+ * @{
+ */
+#include "ti-lib.h"
+#include "contiki.h"
+#include "contiki-net.h"
+
+#include "lpm.h"
+#include "gpio-interrupt.h"
+#include "ieee-addr.h"
+#include "vims.h"
+#include "uart.h"
+#include "sys_ctrl.h"
+#include "sys/clock.h"
+#include "sys/rtimer.h"
+#include "sys/node-id.h"
+#include "lib/random.h"
+#include "lib/sensors.h"
+#include "dev/watchdog.h"
+#include "dev/oscillators.h"
+#include "dev/serial-line.h"
+#include "dev/cc26xx-uart.h"
+#include "dev/soc-rtc.h"
+#include "rf-core/rf-core.h"
+#include "net/mac/frame802154.h"
+
+#include "driverlib/driverlib_release.h"
+
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+unsigned short node_id = 0;
+/*---------------------------------------------------------------------------*/
+static void
+set_rf_params()
+{
+  uint16_t short_addr;
+  uint8_t ext_addr[8];
+  radio_value_t val = 0;
+
+  ieee_addr_cpy_to(ext_addr, 8);
+
+  short_addr = ext_addr[7];
+  short_addr |= ext_addr[6] << 8;
+
+  /* Populate linkaddr_node_addr. Maintain endianness */
+  memcpy(&linkaddr_node_addr, &ext_addr[8 - LINKADDR_SIZE], LINKADDR_SIZE);
+
+  NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, RF_CORE_CHANNEL);
+  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+
+  NETSTACK_RADIO.get_value(RADIO_PARAM_CHANNEL, &val);
+  printf(" RF: Channel %d\n", val);
+
+#if STARTUP_CONF_VERBOSE
+  {
+    int i;
+    printf(" Link layer addr: ");
+    for(i = 0; i < LINKADDR_SIZE - 1; i++) {
+      printf("%02x:", linkaddr_node_addr.u8[i]);
+    }
+    printf("%02x\n", linkaddr_node_addr.u8[i]);
+  }
+#endif
+
+  /* also set the global node id */
+  node_id = short_addr;
+  printf(" Node ID: %d\n", node_id);
+}
+/*---------------------------------------------------------------------------*/
+static void
+wakeup_handler(void)
+{
+  /* Turn on the PERIPH PD */
+  ti_lib_prcm_power_domain_on(PRCM_DOMAIN_PERIPH);
+  while((ti_lib_prcm_power_domain_status(PRCM_DOMAIN_PERIPH)
+        != PRCM_DOMAIN_POWER_ON));
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Declare a data structure to register with LPM.
+ * We don't care about what power mode we'll drop to, we don't care about
+ * getting notified before deep sleep. All we need is to be notified when we
+ * wake up so we can turn power domains back on
+ */
+LPM_MODULE(coua_lpm_module, NULL, NULL, wakeup_handler, LPM_DOMAIN_NONE);
+/*---------------------------------------------------------------------------*/
+void
+board_init()
+{
+  /* Disable global interrupts */
+  bool int_disabled = ti_lib_int_master_disable();
+
+  wakeup_handler();
+
+  /* Enable GPIO peripheral */
+  ti_lib_prcm_peripheral_run_enable(PRCM_PERIPH_GPIO);
+
+  /* Apply settings and wait for them to take effect */
+  ti_lib_prcm_load_set();
+  while(!ti_lib_prcm_load_get());
+
+  lpm_register_module(&coua_lpm_module);
+
+  /* Re-enable interrupt if initially enabled. */
+  if(!int_disabled) {
+    ti_lib_int_master_enable();
+  }
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Main function for the Coua
+ */
+int
+main(void)
+{
+  /* Enable flash cache and prefetch. */
+  ti_lib_vims_mode_set(VIMS_BASE, VIMS_MODE_ENABLED);
+  ti_lib_vims_configure(VIMS_BASE, true, true);
+
+  ti_lib_int_master_disable();
+
+  /* Set the LF XOSC as the LF system clock source */
+  oscillators_select_lf_xosc();
+
+  lpm_init();
+
+  board_init();
+
+  gpio_interrupt_init();
+
+  /*
+   * Disable I/O pad sleep mode and open I/O latches in the AON IOC interface
+   * This is only relevant when returning from shutdown (which is what froze
+   * latches in the first place. Before doing these things though, we should
+   * allow software to first regain control of pins
+   */
+  ti_lib_pwr_ctrl_io_freeze_disable();
+
+  ti_lib_int_master_enable();
+
+  soc_rtc_init();
+  clock_init();
+  rtimer_init();
+
+  watchdog_init();
+  process_init();
+
+  random_init(0x1234);
+
+  /* Character I/O Initialisation */
+#if CC26XX_UART_CONF_ENABLE
+  cc26xx_uart_init();
+#endif
+
+  serial_line_init();
+
+  printf("Starting " CONTIKI_VERSION_STRING "\n");
+  printf("With DriverLib v%u.%u\n", DRIVERLIB_RELEASE_GROUP,
+         DRIVERLIB_RELEASE_BUILD);
+  printf(BOARD_STRING "\n");
+  printf("IEEE 802.15.4: %s, Sub-GHz: %s, BLE: %s, Prop: %s\n",
+         ti_lib_chipinfo_supports_ieee_802_15_4() == true ? "Yes" : "No",
+         ti_lib_chipinfo_chip_family_is_cc13xx() == true ? "Yes" : "No",
+         ti_lib_chipinfo_supports_ble() == true ? "Yes" : "No",
+         ti_lib_chipinfo_supports_proprietary() == true ? "Yes" : "No");
+
+
+  process_start(&etimer_process, NULL);
+  ctimer_init();
+
+  energest_init();
+  ENERGEST_ON(ENERGEST_TYPE_CPU);
+
+  printf(" Net: ");
+  printf("%s\n", NETSTACK_NETWORK.name);
+  printf(" MAC: ");
+  printf("%s\n", NETSTACK_MAC.name);
+  printf(" RDC: ");
+  printf("%s", NETSTACK_RDC.name);
+
+  if(NETSTACK_RDC.channel_check_interval() != 0) {
+    printf(", Channel Check Interval: %u ticks",
+           NETSTACK_RDC.channel_check_interval());
+  }
+  printf("\n");
+
+  netstack_init();
+  set_rf_params();
+
+#if NETSTACK_CONF_WITH_IPV6
+  memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));
+  queuebuf_init();
+  process_start(&tcpip_process, NULL);
+#endif /* NETSTACK_CONF_WITH_IPV6 */
+
+  process_start(&sensors_process, NULL);
+
+  autostart_start(autostart_processes);
+
+  watchdog_start();
+
+  while(1) {
+    uint8_t r;
+    do {
+      r = process_run();
+      watchdog_periodic();
+    } while(r > 0);
+
+    /* Drop to some low power mode */
+    lpm_drop();
+  }
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/coua/coua-sensors.c
+++ b/platform/coua/coua-sensors.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup coua-sensors
+ * @{
+ *
+ * \file
+ *      Generic module controlling Coua sensors
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/button-sensor.h"
+
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+/** \brief Exports a global symbol to be used by the sensor API */
+SENSORS(&button_sensor);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/coua/leds-arch.c
+++ b/platform/coua/leds-arch.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017, Weptech elektronik GmbH Germany
+ * http://www.weptech.de
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup coua-peripherals
+ * @{
+ *
+ * \file
+ *      Driver for Coua LEDs
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "board.h"
+
+#include "ti-lib.h"
+/*---------------------------------------------------------------------------*/
+static unsigned char c;
+static int inited = 0;
+/*---------------------------------------------------------------------------*/
+void
+leds_arch_init(void)
+{
+  if(inited) {
+    return;
+  }
+  inited = 1;
+
+  ti_lib_rom_ioc_pin_type_gpio_output(BOARD_IOID_LED);
+
+  ti_lib_gpio_clear_multi_dio(BOARD_LED_ALL);
+}
+/*---------------------------------------------------------------------------*/
+unsigned char
+leds_arch_get(void)
+{
+  return c;
+}
+/*---------------------------------------------------------------------------*/
+void
+leds_arch_set(unsigned char leds)
+{
+  c = leds;
+  ti_lib_gpio_clear_multi_dio(BOARD_LED_ALL);
+  if((leds & LEDS_YELLOW) == LEDS_YELLOW) {
+    ti_lib_gpio_set_dio(BOARD_IOID_LED);
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */


### PR DESCRIPTION
This PR consists of two commits. One adds support for the bare Coua board with a simple MQTT client example, as well as support for Sensniff and Contiki's standard ipv6/rpl-border-router example. The other outlines the modifications that we made when we expanded the Coua with an LED and a button on a breadboard.